### PR TITLE
Added tests for home interactor

### DIFF
--- a/src/test/java/use_case/home/HomeInteractorTest.java
+++ b/src/test/java/use_case/home/HomeInteractorTest.java
@@ -1,0 +1,70 @@
+package use_case.home;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HomeInteractorTest {
+    private HomeInteractor homeInteractor;
+    private HomeOutputBoundary outputBoundary;
+
+    @BeforeEach
+    void setUp() {
+        outputBoundary = new TestHomeOutputBoundary();
+        homeInteractor = new HomeInteractor(outputBoundary);
+    }
+
+    @Test
+    void testSwitchToBudgetCompare() {
+        homeInteractor.switchToBudgetCompare();
+        assertTrue(((TestHomeOutputBoundary) outputBoundary).switchToBudgetCompareCalled);
+    }
+
+    @Test
+    void testSwitchToBudgetMaker() {
+        homeInteractor.switchToBudgetMaker();
+        assertTrue(((TestHomeOutputBoundary) outputBoundary).switchToBudgetMakerCalled);
+    }
+
+    @Test
+    void testSwitchToBudgetTracker() {
+        homeInteractor.switchToBudgetTracker();
+        assertTrue(((TestHomeOutputBoundary) outputBoundary).switchToBudgetTrackerCalled);
+    }
+
+    @Test
+    void testSwitchToChatBot() {
+        homeInteractor.switchToChatBot();
+        assertTrue(((TestHomeOutputBoundary) outputBoundary).switchToChatBotCalled);
+    }
+
+    private static class TestHomeOutputBoundary implements HomeOutputBoundary {
+
+        boolean switchToBudgetMakerCalled = false;
+        boolean switchToBudgetTrackerCalled = false;
+        boolean switchToBudgetCompareCalled = false;
+        boolean switchToChatBotCalled = false;
+
+        @Override
+        public void switchToBudgetMaker() {
+            switchToBudgetMakerCalled = true;
+        }
+
+        @Override
+        public void switchToBudgetTracker() {
+            switchToBudgetTrackerCalled = true;
+        }
+
+        @Override
+        public void switchToBudgetCompare() {
+            switchToBudgetCompareCalled = true;
+        }
+
+        @Override
+        public void switchToChatBot() {
+            switchToChatBotCalled = true;
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request Description

**Summary**:  
This pull request adds unit tests for the `HomeInteractor` class, which is responsible for handling the logic of switching between different views (Budget Maker, Budget Tracker, Budget Compare, and ChatBot) in the home screen. The tests ensure that the appropriate methods in the `HomeOutputBoundary` are called when invoking the corresponding methods in `HomeInteractor`.

**Changes Made**:
1. **Test Class**: 
   - Created a test class `HomeInteractorTest` to verify the functionality of the `HomeInteractor` class.
   - Used the `JUnit 5` testing framework with `@BeforeEach` and `@Test` annotations to set up and run the tests.

2. **Test Methods**:
   - **testSwitchToBudgetCompare**: Verifies that the `switchToBudgetCompare` method in the `HomeInteractor` calls the appropriate method in the `HomeOutputBoundary`.
   - **testSwitchToBudgetMaker**: Verifies that the `switchToBudgetMaker` method in the `HomeInteractor` calls the appropriate method in the `HomeOutputBoundary`.
   - **testSwitchToBudgetTracker**: Verifies that the `switchToBudgetTracker` method in the `HomeInteractor` calls the appropriate method in the `HomeOutputBoundary`.
   - **testSwitchToChatBot**: Verifies that the `switchToChatBot` method in the `HomeInteractor` calls the appropriate method in the `HomeOutputBoundary`.

3. **Test Stub**:
   - **TestHomeOutputBoundary**: A mock implementation of the `HomeOutputBoundary` interface to simulate and verify the method calls without needing the actual implementation. This mock class tracks whether the respective `switchTo` methods were called.

**Reason for the Pull Request**:  
The purpose of this pull request is to ensure that the `HomeInteractor` behaves correctly by calling the expected methods in the `HomeOutputBoundary` based on the user actions. This is a crucial part of the application logic that handles view transitions.

**Testing**:  
- Unit tests are executed for all major actions in `HomeInteractor`.
- Each test asserts that the corresponding `switchTo` method is called in the mock `HomeOutputBoundary`.

This pull request improves test coverage and helps ensure that view transitions are handled properly.